### PR TITLE
GPU bugfixes

### DIFF
--- a/jobinfo
+++ b/jobinfo
@@ -17,13 +17,21 @@ import json
 import math
 import os
 import pwd
-import pynumparser
 import re
 import requests
 import subprocess
 import sys
 import time
 
+# pynumparser should have been installed to /usr/lib.
+# However, if another Python version is loaded as module,
+# Python may fail to find pynumparser. In this case we add it
+# to the search path manually and try again.
+try:
+    import pynumparser
+except ModuleNotFoundError:
+    sys.path.append('/usr/lib/python2.7/site-packages/')
+    import pynumparser
 
 def append(l, x):
     if l == '':

--- a/jobinfo
+++ b/jobinfo
@@ -379,9 +379,14 @@ def main(jobid):
             for gpu, usage in gpu_usages:
                 print('%-20s: %.1f%% (%s)' % ('Average GPU usage', usage, gpu))
         except Exception as e:
-            print('\nGPU usage could not be retreived',
-                  'The error was:\n')
-            print(e, file=sys.stderr)
+            if type(e) == IndexError:
+                print(
+                    '\nError: No GPU metrics available ({})'.format(y[3]),
+                    file=sys.stderr)
+            else:
+                print('\nGPU usage could not be retrieved.',
+                      'The error was:\n')
+                print(e, file=sys.stderr)
 
 
 def usage(pipe):

--- a/jobinfo
+++ b/jobinfo
@@ -356,7 +356,7 @@ def main(jobid):
             print("%-20s: %s" % (desc, format(val, meta)))
 
     # for  gpu jobs, retreive gpu usage from prometheus.
-    if y[2] == 'gpu':
+    if y[2] == 'gpu' and y[7] != 'Unknown':
         start = time.mktime(datetime.datetime.strptime(
             y[7], '%Y-%m-%dT%H:%M:%S').timetuple())
         if y[8] == 'Unknown':

--- a/jobinfo
+++ b/jobinfo
@@ -29,7 +29,7 @@ import time
 # to the search path manually and try again.
 try:
     import pynumparser
-except ModuleNotFoundError:
+except ImportError:
     sys.path.append('/usr/lib/python2.7/site-packages/')
     import pynumparser
 

--- a/jobinfo.spec
+++ b/jobinfo.spec
@@ -1,5 +1,5 @@
 Name: jobinfo
-Version: 1.2
+Version: 1.3.0
 Release: 1%{?dist}
 Summary: Collect job information from SLURM in nicely readable format.
 
@@ -36,6 +36,9 @@ install pynumparser.py $RPM_BUILD_ROOT/usr/lib/python2.7/site-packages
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Wed Mar 18 2020 Bob Dröge <b.e.droge@rug.nl> - 1.3.0
+- Fix bug: do not attempt to parse Unknown as date for waiting jobs
+
 * Mon Mar 16 2020 Bob Dröge <b.e.droge@rug.nl> - 1.2
 - Support for multiple GPUs, implemented by Egon Rijpkema
 - Stick to Python2 for now (default in CentOS 6)

--- a/jobinfo.spec
+++ b/jobinfo.spec
@@ -1,5 +1,5 @@
 Name: jobinfo
-Version: 1.3.0
+Version: 1.3.1
 Release: 1%{?dist}
 Summary: Collect job information from SLURM in nicely readable format.
 
@@ -36,6 +36,9 @@ install pynumparser.py $RPM_BUILD_ROOT/usr/lib/python2.7/site-packages
 rm -rf $RPM_BUILD_ROOT
 
 %changelog
+* Mon Mar 23 2020 Bob Dröge <b.e.droge@rug.nl> - 1.3.1
+- Bugfix: pynumparser could not be found when another Python version was loaded as module.
+
 * Wed Mar 18 2020 Bob Dröge <b.e.droge@rug.nl> - 1.3.0
 - Fix bug: do not attempt to parse Unknown as date for waiting jobs
 

--- a/jobinfo.spec
+++ b/jobinfo.spec
@@ -1,6 +1,6 @@
 Name: jobinfo
 Version: 1.3.1
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: Collect job information from SLURM in nicely readable format.
 
 Group: System Environment/Base


### PR DESCRIPTION
Be more graceful when there is no GPU data available.

Also do not attempt to retrieve GPU usage when the job hasn't started yet.