### PR TITLE
Report GPU usage of 0.0% instead of 'no metrics available'

### DIFF
--- a/jobinfo
+++ b/jobinfo
@@ -477,7 +477,7 @@ def main(jobid):
         try:
             gpu_usages = get_gpus_usage(meta.NodeList, start, end)
             for gpu, usage in gpu_usages:
-                if usage>0:
+                if usage >= 0:
                     print('%-20s: %.1f%% (%s)' % ('Average GPU usage', usage, gpu))
                 else:
                     print('%-20s: No GPU metrics available (%s)' % ('Average GPU usage', gpu))


### PR DESCRIPTION
In cases where the GPU usage is 0.0, jobinfo reports `No metrics available` for the GPU usage, which I find confusing. So I changed the `>0` check to `>=0`.